### PR TITLE
Adding check for StatusCode

### DIFF
--- a/teeproxy.go
+++ b/teeproxy.go
@@ -102,7 +102,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	resp, err := clientHttpConn.Read(productionRequest) // Read back the reply
-	if err != nil {
+	if err != nil && resp.StatusCode != 200 {
 		fmt.Printf("Failed to receive from %s: %v\n", h.Target, err)
 		return
 	}


### PR DESCRIPTION
There are certain conditions where we will get a StatusCode of 200 and get an
error message ("Failed to receive from localhost:8080: persistent connection
closed").

That will prevent the response data from the 'a' system being sent back to the
client. This check will allow that data to be sent back as expected.