### PR TITLE
close response handle, fixes #15

### DIFF
--- a/teeproxy.go
+++ b/teeproxy.go
@@ -112,6 +112,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 	body, _ := ioutil.ReadAll(resp.Body)
 	w.Write(body)
+	defer resp.Body.Close()
 }
 
 func main() {


### PR DESCRIPTION
We should close `resp.Body` after handling the response.