### PR TITLE
Improve the shape of the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _testmain.go
 
 *.exe
 *.test
+teeproxy

--- a/teeproxy.go
+++ b/teeproxy.go
@@ -17,68 +17,83 @@ import (
 
 // Console flags
 var (
-	listen                = flag.String("l", ":8888", "port to accept requests")
-	targetProduction      = flag.String("a", "localhost:8080", "where production traffic goes. http://localhost:8080/production")
-	altTarget             = flag.String("b", "localhost:8081", "where testing traffic goes. response are skipped. http://localhost:8081/test")
-	debug                 = flag.Bool("debug", false, "more logging, showing ignored output")
-	productionTimeout     = flag.Int("a.timeout", 3, "timeout in seconds for production traffic")
-	alternateTimeout      = flag.Int("b.timeout", 1, "timeout in seconds for alternate site traffic")
-	productionHostRewrite = flag.Bool("a.rewrite", false, "rewrite the host header when proxying production traffic")
-	alternateHostRewrite  = flag.Bool("b.rewrite", false, "rewrite the host header when proxying alternate site traffic")
-	percent               = flag.Float64("p", 100.0, "float64 percentage of traffic to send to testing")
-	tlsPrivateKey         = flag.String("key.file", "", "path to the TLS private key file")
-	tlsCertificate        = flag.String("cert.file", "", "path to the TLS certificate file")
+	listen  = flag.String("l", ":8888", "port to accept requests")
+	percent = flag.Float64("p", 100.0, "float64 percentage of traffic to send to testing")
+
+	targetA  = flag.String("a", "localhost:8080", "where production traffic goes. http://localhost:8080/production")
+	timeoutA = flag.Int("a.timeout", 3, "timeout in seconds for production traffic")
+	rewriteA = flag.Bool("a.rewrite", false, "rewrite the host header when proxying production traffic")
+
+	targetB  = flag.String("b", "localhost:8081", "where testing traffic goes. response are skipped. http://localhost:8081/test")
+	timeoutB = flag.Int("b.timeout", 1, "timeout in seconds for alternate site traffic")
+	rewriteB = flag.Bool("b.rewrite", false, "rewrite the host header when proxying alternate site traffic")
+
+	tlsKey = flag.String("key.file", "", "path to the TLS private key file")
+	tlsCer = flag.String("cert.file", "", "path to the TLS certificate file")
+
+	debug = flag.Bool("debug", false, "more logging, showing ignored output")
 )
 
 // handler contains the address of the main Target and the one for the Alternative target
 type handler struct {
-	Target      string
-	Alternative string
-	Randomizer  rand.Rand
+	TargetA string
+	TargetB string
+	Factor  rand.Rand
 }
 
 // ServeHTTP duplicates the incoming request (req) and does the request to the Target and the Alternate target discading the Alternate response
 func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	var productionRequest, alternativeRequest *http.Request
-	if *percent == 100.0 || h.Randomizer.Float64()*100 < *percent {
-		alternativeRequest, productionRequest = DuplicateRequest(req)
+	var requestA, requestB *http.Request
+	if *percent == 100.0 || h.Factor.Float64()*100 < *percent {
+		requestA, requestB = DuplicateRequest(req)
 		go func() {
 			defer func() {
 				if r := recover(); r != nil && *debug {
 					fmt.Println("Recovered in f", r)
 				}
 			}()
+
 			// Open new TCP connection to the server
-			clientTcpConn, err := net.DialTimeout("tcp", h.Alternative, time.Duration(time.Duration(*alternateTimeout)*time.Second))
+			clientTCPConn, err := net.DialTimeout("tcp", h.TargetB, time.Duration(*timeoutB)*time.Second)
 			if err != nil {
 				if *debug {
-					fmt.Printf("Failed to connect to %s\n", h.Alternative)
+					fmt.Printf("Failed to connect to %s\n", h.TargetB)
 				}
 				return
 			}
-			clientHttpConn := httputil.NewClientConn(clientTcpConn, nil) // Start a new HTTP connection on it
-			defer clientHttpConn.Close()                                 // Close the connection to the server
-			if *alternateHostRewrite {
-				alternativeRequest.Host = h.Alternative
+
+			clientHTTPConn := httputil.NewClientConn(clientTCPConn, nil) // Start a new HTTP connection on it
+
+			defer func() { // Close the connection to the server
+				if cerr := clientHTTPConn.Close(); cerr != nil {
+					fmt.Print(cerr)
+				}
+			}()
+
+			if *rewriteB {
+				requestB.Host = h.TargetB
 			}
-			err = clientHttpConn.Write(alternativeRequest) // Pass on the request
+
+			err = clientHTTPConn.Write(requestB) // Pass on the request
 			if err != nil {
 				if *debug {
-					fmt.Printf("Failed to send to %s: %v\n", h.Alternative, err)
+					fmt.Printf("Failed to send to %s: %v\n", h.TargetB, err)
 				}
 				return
 			}
-			_, err = clientHttpConn.Read(alternativeRequest) // Read back the reply
+
+			_, err = clientHTTPConn.Read(requestB) // Read back the reply
 			if err != nil {
 				if *debug {
-					fmt.Printf("Failed to receive from %s: %v\n", h.Alternative, err)
+					fmt.Printf("Failed to receive from %s: %v\n", h.TargetB, err)
 				}
 				return
 			}
 		}()
 	} else {
-		productionRequest = req
+		requestA = req
 	}
+
 	defer func() {
 		if r := recover(); r != nil && *debug {
 			fmt.Println("Recovered in f", r)
@@ -86,33 +101,57 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}()
 
 	// Open new TCP connection to the server
-	clientTcpConn, err := net.DialTimeout("tcp", h.Target, time.Duration(time.Duration(*productionTimeout)*time.Second))
+	clientTCPConn, err := net.DialTimeout("tcp", h.TargetA, time.Duration(*timeoutA)*time.Second)
 	if err != nil {
-		fmt.Printf("Failed to connect to %s\n", h.Target)
+		fmt.Printf("Failed to connect to %s\n", h.TargetA)
 		return
 	}
-	clientHttpConn := httputil.NewClientConn(clientTcpConn, nil) // Start a new HTTP connection on it
-	defer clientHttpConn.Close()                                 // Close the connection to the server
-	if *productionHostRewrite {
-		productionRequest.Host = h.Target
+
+	clientHTTPConn := httputil.NewClientConn(clientTCPConn, nil) // Start a new HTTP connection on it
+
+	defer func() { // Close the connection to the server
+		if cerr := clientHTTPConn.Close(); cerr != nil {
+			fmt.Print(cerr)
+		}
+	}()
+
+	if *rewriteA {
+		requestA.Host = h.TargetA
 	}
-	err = clientHttpConn.Write(productionRequest) // Pass on the request
+
+	err = clientHTTPConn.Write(requestA) // Pass on the request
 	if err != nil {
-		fmt.Printf("Failed to send to %s: %v\n", h.Target, err)
+		fmt.Printf("Failed to send to %s: %v\n", h.TargetA, err)
 		return
 	}
-	resp, err := clientHttpConn.Read(productionRequest) // Read back the reply
+
+	resp, err := clientHTTPConn.Read(requestA) // Read back the reply
 	if err != nil {
-		fmt.Printf("Failed to receive from %s: %v\n", h.Target, err)
+		fmt.Printf("Failed to receive from %s: %v\n", h.TargetA, err)
 		return
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Print(cerr)
+		}
+	}()
+
 	for k, v := range resp.Header {
 		w.Header()[k] = v
 	}
+
 	w.WriteHeader(resp.StatusCode)
-	body, _ := ioutil.ReadAll(resp.Body)
-	w.Write(body)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Print(err)
+	}
+
+	_, werr := w.Write(body)
+	if werr != nil {
+		fmt.Print(werr)
+	}
 }
 
 func main() {
@@ -121,13 +160,13 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	var err error
-
+	var cer tls.Certificate
 	var listener net.Listener
 
-	if len(*tlsPrivateKey) > 0 {
-		cer, err := tls.LoadX509KeyPair(*tlsCertificate, *tlsPrivateKey)
+	if len(*tlsKey) > 0 {
+		cer, err = tls.LoadX509KeyPair(*tlsCer, *tlsKey)
 		if err != nil {
-			fmt.Printf("Failed to load certficate: %s and private key: %s", *tlsCertificate, *tlsPrivateKey)
+			fmt.Printf("Failed to load certficate: %s and private key: %s", *tlsCer, *tlsKey)
 			return
 		}
 
@@ -146,11 +185,15 @@ func main() {
 	}
 
 	h := handler{
-		Target:      *targetProduction,
-		Alternative: *altTarget,
-		Randomizer:  *rand.New(rand.NewSource(time.Now().UnixNano())),
+		TargetA: *targetA,
+		TargetB: *targetB,
+		Factor:  *rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
-	http.Serve(listener, h)
+
+	err = http.Serve(listener, h)
+	if err != nil {
+		fmt.Print(err)
+	}
 }
 
 type nopCloser struct {
@@ -159,13 +202,23 @@ type nopCloser struct {
 
 func (nopCloser) Close() error { return nil }
 
-func DuplicateRequest(request *http.Request) (request1 *http.Request, request2 *http.Request) {
+// DuplicateRequest is not documented.
+func DuplicateRequest(request *http.Request) (requestA *http.Request, requestB *http.Request) {
 	b1 := new(bytes.Buffer)
 	b2 := new(bytes.Buffer)
 	w := io.MultiWriter(b1, b2)
-	io.Copy(w, request.Body)
-	defer request.Body.Close()
-	request1 = &http.Request{
+	_, err := io.Copy(w, request.Body)
+	if err != nil {
+		fmt.Print(err)
+	}
+
+	defer func() {
+		if err := request.Body.Close(); err != nil {
+			fmt.Print(err)
+		}
+	}()
+
+	requestA = &http.Request{
 		Method:        request.Method,
 		URL:           request.URL,
 		Proto:         request.Proto,
@@ -176,7 +229,8 @@ func DuplicateRequest(request *http.Request) (request1 *http.Request, request2 *
 		Host:          request.Host,
 		ContentLength: request.ContentLength,
 	}
-	request2 = &http.Request{
+
+	requestB = &http.Request{
 		Method:        request.Method,
 		URL:           request.URL,
 		Proto:         request.Proto,
@@ -187,5 +241,6 @@ func DuplicateRequest(request *http.Request) (request1 *http.Request, request2 *
 		Host:          request.Host,
 		ContentLength: request.ContentLength,
 	}
+
 	return
 }

--- a/teeproxy.go
+++ b/teeproxy.go
@@ -17,21 +17,21 @@ import (
 
 // Console flags
 var (
-	listen  = flag.String("l", ":8888", "port to accept requests")
-	percent = flag.Float64("p", 100.0, "float64 percentage of traffic to send to testing")
+	targetA  = flag.String("a", "localhost:8080", "A side host:port address")
+	timeoutA = flag.Int("a.timeout", 3, "A side timeout")
+	rewriteA = flag.Bool("a.rewrite", false, "A side header rewrite flag.")
 
-	targetA  = flag.String("a", "localhost:8080", "where production traffic goes. http://localhost:8080/production")
-	timeoutA = flag.Int("a.timeout", 3, "timeout in seconds for production traffic")
-	rewriteA = flag.Bool("a.rewrite", false, "rewrite the host header when proxying production traffic")
+	targetB  = flag.String("b", "localhost:8081", "A side host:port address")
+	timeoutB = flag.Int("b.timeout", 1, "B side timeout")
+	rewriteB = flag.Bool("b.rewrite", false, "B side header rewrite flag")
 
-	targetB  = flag.String("b", "localhost:8081", "where testing traffic goes. response are skipped. http://localhost:8081/test")
-	timeoutB = flag.Int("b.timeout", 1, "timeout in seconds for alternate site traffic")
-	rewriteB = flag.Bool("b.rewrite", false, "rewrite the host header when proxying alternate site traffic")
+	listen  = flag.String("l", ":8888", "Listener (proxy) port number")
+	percent = flag.Float64("p", 100.0, "Percent of traffic to send to B side")
 
-	tlsKey = flag.String("key.file", "", "path to the TLS private key file")
-	tlsCer = flag.String("cert.file", "", "path to the TLS certificate file")
+	tlsCer = flag.String("tls.cer", "", "TLS certificate file path")
+	tlsKey = flag.String("tls.key", "", "TLS private key file path")
 
-	debug = flag.Bool("debug", false, "more logging, showing ignored output")
+	debug = flag.Bool("debug", false, "Debug log level")
 )
 
 // handler contains the address of the main Target and the one for the Alternative target


### PR DESCRIPTION
* Add whitespace
* Reduce the number of names for related things to A/B
  from production/alternate and A/B and 1/2
* Reorder all the A/B from various mixes to A/B
* Remove most lint (using gometalinter), mostly unchecked for errors.
* Order flags more closely to how they are displayed
* Shorten the user help message and use parallel construction

**_BREAKING CHANGE_**

* `-key.file`/`-cert.file` to `-tls.cer`/`-tls.key` for parallel construction

This offered ahead of another refactor to reduce cyclomatic complexity of `ServeHTTP`.
And, perhaps, some tests to make refactoring, modification, and other additions less stressful.