### PR TITLE
ClientConn.Read can return ErrPersistEOF "error" on success

### DIFF
--- a/teeproxy.go
+++ b/teeproxy.go
@@ -69,7 +69,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 			_, err = clientHttpConn.Read(alternativeRequest) // Read back the reply
-			if err != nil {
+			if err != nil && err != httputil.ErrPersistEOF {
 				if *debug {
 					fmt.Printf("Failed to receive from %s: %v\n", h.Alternative, err)
 				}
@@ -102,7 +102,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	resp, err := clientHttpConn.Read(productionRequest) // Read back the reply
-	if err != nil {
+	if err != nil && err != httputil.ErrPersistEOF {
 		fmt.Printf("Failed to receive from %s: %v\n", h.Target, err)
 		return
 	}


### PR DESCRIPTION
https://golang.org/pkg/net/http/httputil/#ClientConn.Read

Even when a Read is valid, it may still return ErrPersistEOF as a signal
that the connection should not be kept open.

This is a fix to properly expect ErrPersistEOF and not treat it as
an error.
