### PR TITLE
Replace deprecated methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _testmain.go
 
 *.exe
 *.test
+teeproxy
+

--- a/teeproxy.go
+++ b/teeproxy.go
@@ -150,7 +150,11 @@ func main() {
 		Alternative: *altTarget,
 		Randomizer:  *rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
-	http.Serve(listener, h)
+
+	server := &http.Server{
+		Handler: h,
+	}
+	server.Serve(listener)
 }
 
 type nopCloser struct {

--- a/teeproxy.go
+++ b/teeproxy.go
@@ -10,7 +10,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
-	"net/http/httputil"
+	"net/url"
 	"runtime"
 	"time"
 )
@@ -21,14 +21,57 @@ var (
 	targetProduction      = flag.String("a", "localhost:8080", "where production traffic goes. http://localhost:8080/production")
 	altTarget             = flag.String("b", "localhost:8081", "where testing traffic goes. response are skipped. http://localhost:8081/test")
 	debug                 = flag.Bool("debug", false, "more logging, showing ignored output")
-	productionTimeout     = flag.Int("a.timeout", 3, "timeout in seconds for production traffic")
-	alternateTimeout      = flag.Int("b.timeout", 1, "timeout in seconds for alternate site traffic")
+	productionTimeout     = flag.Int("a.timeout", 2500, "timeout in milliseconds for production traffic")
+	alternateTimeout      = flag.Int("b.timeout", 1000, "timeout in milliseconds for alternate site traffic")
 	productionHostRewrite = flag.Bool("a.rewrite", false, "rewrite the host header when proxying production traffic")
 	alternateHostRewrite  = flag.Bool("b.rewrite", false, "rewrite the host header when proxying alternate site traffic")
 	percent               = flag.Float64("p", 100.0, "float64 percentage of traffic to send to testing")
 	tlsPrivateKey         = flag.String("key.file", "", "path to the TLS private key file")
 	tlsCertificate        = flag.String("cert.file", "", "path to the TLS certificate file")
 )
+
+
+// Sets the request URL.
+//
+// This turns a inbound request (a request without URL) into an outbound request.
+func setRequestTarget(request *http.Request, target *string) {
+	URL, err := url.Parse("http://" + *target + request.URL.String())
+	if err != nil {
+		fmt.Println(err)
+	}
+	request.URL = URL
+}
+
+
+// Sends a request and returns the response.
+func handleRequest(request *http.Request, timeout time.Duration) (*http.Response) {
+	transport := &http.Transport{
+		// NOTE(girone): DialTLS is not needed here, because the teeproxy works
+		// as an SSL terminator.
+		Dial: (&net.Dialer{  // go1.8 deprecated: Use DialContext instead
+			Timeout: timeout,
+			KeepAlive: 10 * timeout,
+		}).Dial,
+		// Always close connections to the alternative and production servers.
+		DisableKeepAlives: true,
+		//IdleConnTimeout: timeout,  // go1.8
+		TLSHandshakeTimeout: timeout,
+		ResponseHeaderTimeout: timeout,
+		ExpectContinueTimeout: timeout,
+	}
+	// Do not use http.Client here, because it's higher level and processes
+	// redirects internally, which is not what we want.
+	//client := &http.Client{
+	//	Timeout: timeout,
+	//	Transport: transport,
+	//}
+	//response, err := client.Do(request)
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		fmt.Println("Request failed:", err)
+	}
+	return response
+}
 
 // handler contains the address of the main Target and the one for the Alternative target
 type handler struct {
@@ -37,7 +80,8 @@ type handler struct {
 	Randomizer  rand.Rand
 }
 
-// ServeHTTP duplicates the incoming request (req) and does the request to the Target and the Alternate target discading the Alternate response
+// ServeHTTP duplicates the incoming request (req) and does the request to the
+// Target and the Alternate target discading the Alternate response
 func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var productionRequest, alternativeRequest *http.Request
 	if *percent == 100.0 || h.Randomizer.Float64()*100 < *percent {
@@ -45,78 +89,58 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil && *debug {
-					fmt.Println("Recovered in f", r)
+					fmt.Println("Recovered in ServeHTTP(alternate request) from:", r)
 				}
 			}()
-			// Open new TCP connection to the server
-			clientTcpConn, err := net.DialTimeout("tcp", h.Alternative, time.Duration(time.Duration(*alternateTimeout)*time.Second))
-			if err != nil {
-				if *debug {
-					fmt.Printf("Failed to connect to %s\n", h.Alternative)
-				}
-				return
-			}
-			clientHttpConn := httputil.NewClientConn(clientTcpConn, nil) // Start a new HTTP connection on it
-			defer clientHttpConn.Close()                                 // Close the connection to the server
+
+			setRequestTarget(alternativeRequest, altTarget)
+
 			if *alternateHostRewrite {
 				alternativeRequest.Host = h.Alternative
 			}
-			err = clientHttpConn.Write(alternativeRequest) // Pass on the request
-			if err != nil {
-				if *debug {
-					fmt.Printf("Failed to send to %s: %v\n", h.Alternative, err)
-				}
-				return
-			}
-			_, err = clientHttpConn.Read(alternativeRequest) // Read back the reply
-			if err != nil && err != httputil.ErrPersistEOF {
-				if *debug {
-					fmt.Printf("Failed to receive from %s: %v\n", h.Alternative, err)
-				}
-				return
-			}
+
+			timeout := time.Duration(*alternateTimeout) * time.Millisecond
+			// This keeps responses from the alternative target away from the outside world.
+			_ = handleRequest(alternativeRequest, timeout)
 		}()
 	} else {
 		productionRequest = req
 	}
 	defer func() {
 		if r := recover(); r != nil && *debug {
-			fmt.Println("Recovered in f", r)
+			fmt.Println("Recovered in ServeHTTP(production request) from:", r)
 		}
 	}()
 
-	// Open new TCP connection to the server
-	clientTcpConn, err := net.DialTimeout("tcp", h.Target, time.Duration(time.Duration(*productionTimeout)*time.Second))
-	if err != nil {
-		fmt.Printf("Failed to connect to %s\n", h.Target)
-		return
-	}
-	clientHttpConn := httputil.NewClientConn(clientTcpConn, nil) // Start a new HTTP connection on it
-	defer clientHttpConn.Close()                                 // Close the connection to the server
+	setRequestTarget(productionRequest, targetProduction)
+
 	if *productionHostRewrite {
 		productionRequest.Host = h.Target
 	}
-	err = clientHttpConn.Write(productionRequest) // Pass on the request
-	if err != nil {
-		fmt.Printf("Failed to send to %s: %v\n", h.Target, err)
-		return
+
+	timeout := time.Duration(*productionTimeout) * time.Millisecond
+	resp := handleRequest(productionRequest, timeout)
+
+	if resp != nil {
+		defer resp.Body.Close()
+
+		// Forward response headers.
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(resp.StatusCode)
+
+		// Forward response body.
+		body, _ := ioutil.ReadAll(resp.Body)
+		w.Write(body)
 	}
-	resp, err := clientHttpConn.Read(productionRequest) // Read back the reply
-	if err != nil && err != httputil.ErrPersistEOF {
-		fmt.Printf("Failed to receive from %s: %v\n", h.Target, err)
-		return
-	}
-	defer resp.Body.Close()
-	for k, v := range resp.Header {
-		w.Header()[k] = v
-	}
-	w.WriteHeader(resp.StatusCode)
-	body, _ := ioutil.ReadAll(resp.Body)
-	w.Write(body)
 }
 
 func main() {
 	flag.Parse()
+
+	fmt.Printf("Starting teeproxy at %s sending to A: %s and B: %s \n",
+			   *listen, *targetProduction, *altTarget)
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 


### PR DESCRIPTION
Replaces deprecated methods with new calls. Tested until Go 1.9.2 

Includes feedback on #27 to use the `log` package and output to stderr instead of to a file. 

Except for requiring Go > 1.6, the changes are backwards compatible in the sense that any previous use case of teeproxy still works.

This PR prepares several other extensions (more control on connection handling, teeproxy acting as opaque proxy) which I'd like to add in separate PRs.

