### PR TITLE
Close connections to backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ It's possible to write `X-Forwarded-For` and `Forwarded` header (RFC 7239) so
 that the production and alternate backends know about the clients:
 *  `-forward-client-ip` (default is false)
 
+#### Configuring connection handling ####
+By default, teeproxy tries to reuse connections. This can be turned off, if the
+endpoints do not support this.
+*  `-close-connections` (default is false)
+

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ Optionally rewrite host value in the http request header.
 #### Configuring HTTPS ####
 *  `-key.file string`: a TLS private key file. (default `""`)
 *  `-cert.file string`: a TLS certificate file. (default `""`)
+
+#### Configuring client IP forwarding ####
+It's possible to write `X-Forwarded-For` and `Forwarded` header (RFC 7239) so
+that the production and alternate backends know about the clients:
+*  `-forward-client-ip` (default is false)
+

--- a/xff_header_test.go
+++ b/xff_header_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNoHeaderProvided(t *testing.T) {
+	adserverRequest, _ := http.NewRequest("GET", "ad1/test", nil)
+	adserverRequest.RemoteAddr = "192.168.0.1:80"
+	updateForwardedHeaders(adserverRequest)
+	var xffHeader = adserverRequest.Header.Get("X-FORWARDED-FOR")
+	var forwardedHeader = adserverRequest.Header.Get("FORWARDED")
+	if expectation := "192.168.0.1"; xffHeader != expectation {
+		t.Errorf("Expected ''%s'', but received ''%s''", expectation, xffHeader)
+	}
+	if expectation := "for=192.168.0.1"; forwardedHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, forwardedHeader)
+	}
+}
+
+func TestOnlyXFFProvided(t *testing.T) {
+	adserverRequest, _ := http.NewRequest("GET", "ad1/test", nil)
+	adserverRequest.RemoteAddr = "192.168.0.1:80"
+	adserverRequest.Header.Add("X-FORWARDED-FOR", "172.20.2.5")
+	updateForwardedHeaders(adserverRequest)
+	var xffHeader = adserverRequest.Header.Get("X-FORWARDED-FOR")
+	var forwardedHeader = adserverRequest.Header.Get("FORWARDED")
+	if expectation := "172.20.2.5, 192.168.0.1"; xffHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, xffHeader)
+	}
+	if expectation := "for=192.168.0.1"; forwardedHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, forwardedHeader)
+	}
+}
+
+func TestOnlyForwardedProvided(t *testing.T) {
+	adserverRequest, _ := http.NewRequest("GET", "ad1/test", nil)
+	adserverRequest.RemoteAddr = "192.168.0.1:80"
+	adserverRequest.Header.Add("FORWARDED", "for=172.20.2.5")
+	updateForwardedHeaders(adserverRequest)
+	var xffHeader = adserverRequest.Header.Get("X-FORWARDED-FOR")
+	var forwardedHeader = adserverRequest.Header.Get("FORWARDED")
+	if expectation := "192.168.0.1"; xffHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, xffHeader)
+	}
+	if expectation := "for=172.20.2.5, for=192.168.0.1"; forwardedHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, forwardedHeader)
+	}
+}
+
+func TestBothProvided(t *testing.T) {
+	adserverRequest, _ := http.NewRequest("GET", "ad1/test", nil)
+	adserverRequest.RemoteAddr = "192.168.0.1:80"
+	adserverRequest.Header.Add("FORWARDED", "for=172.20.2.5")
+	adserverRequest.Header.Add("X-FORWARDED-FOR", "172.20.2.5")
+	updateForwardedHeaders(adserverRequest)
+	var xffHeader = adserverRequest.Header.Get("X-FORWARDED-FOR")
+	var forwardedHeader = adserverRequest.Header.Get("FORWARDED")
+	if expectation := "172.20.2.5, 192.168.0.1"; xffHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, xffHeader)
+	}
+	if expectation := "for=172.20.2.5, for=192.168.0.1"; forwardedHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, forwardedHeader)
+	}
+}
+
+func TestBothProvidedWithMoreProxies(t *testing.T) {
+	adserverRequest, _ := http.NewRequest("GET", "ad1/test", nil)
+	adserverRequest.RemoteAddr = "192.168.0.15:80"
+	adserverRequest.Header.Add("FORWARDED", "for=172.20.2.5, for=172.20.2.36")
+	adserverRequest.Header.Add("X-FORWARDED-FOR", "172.20.2.5, 172.20.2.36")
+	updateForwardedHeaders(adserverRequest)
+	var xffHeader = adserverRequest.Header.Get("X-FORWARDED-FOR")
+	var forwardedHeader = adserverRequest.Header.Get("FORWARDED")
+	if expectation := "172.20.2.5, 172.20.2.36, 192.168.0.15"; xffHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, xffHeader)
+	}
+	if expectation := "for=172.20.2.5, for=172.20.2.36, for=192.168.0.15"; forwardedHeader != expectation {
+		t.Errorf("Expected '%s', but received '%s'", expectation, forwardedHeader)
+	}
+}


### PR DESCRIPTION
This adds a command line argument to force connections to be closed. This allows to work with backends which do not support reuse of connections. After a while, such setups would run out of available file descriptors.

The default behavior of teeproxy does not change by this.

Solves #29.