### PR TITLE
Allow scheme in backend options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go build
 Usage
 -------------
 ```
- ./teeproxy -l :8888 -a localhost:9000 -b localhost:9001
+ ./teeproxy -l :8888 -a [http(s)://]localhost:9000 -b [http(s)://]localhost:9001
 ```
  `-l` specifies the listening port. `-a` and `-b` are meant for system A and B. The B system can be taken down or started up without causing any issue to the teeproxy.
 


### PR DESCRIPTION
In our case, we need to duplicate requests into mixed http and https backends (some backends aren't accessible via http directly), so I made this small changes to allow use scheme in backend options and support TLS. Feel free to merge it or reject.