### PR TITLE
fix go docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine AS builder
 WORKDIR /go/src/teeproxy
 COPY teeproxy.go ./
-RUN go build -o teeproxy
+RUN go mod init teeproxy && go build -o teeproxy
 
 FROM alpine:3.5 AS runner
 COPY --from=builder /go/src/teeproxy/teeproxy /usr/local/bin


### PR DESCRIPTION
`go build` requires module initialization prior to running.  this modifies the dockerfile to include that step in the build process